### PR TITLE
Fix for bcdata v0.4.0

### DIFF
--- a/01_BaseLayer_Consolidate.Rmd
+++ b/01_BaseLayer_Consolidate.Rmd
@@ -291,7 +291,7 @@ Initially a single function is used to download BEC zone info, VRI shapes, TEM s
   message("\rDownlomapading Road network")
   roads <- bcdc_query_geodata("bb060417-b6e6-4548-b837-f9060d94743e", crs = epsg) %>% 
     bcdata::filter(
-      BBOX(st_bbox(in_aoi), crs = paste0("EPSG:", epsg))) %>%#,
+      BBOX(local(st_bbox(in_aoi), crs = paste0("EPSG:", epsg)))) %>%#,
       #ROAD_NAME_ID > 0) %>% 
     collect() %>% 
     dplyr::select(id, ROAD_NAME_FULL, FEATURE_LENGTH_M) %>% 
@@ -303,7 +303,7 @@ Initially a single function is used to download BEC zone info, VRI shapes, TEM s
   
   fsr <- bcdc_query_geodata("9e5bfa62-2339-445e-bf67-81657180c682", crs = epsg) %>% 
     bcdata::filter(
-      BBOX(st_bbox(in_aoi), crs = paste0("EPSG:", epsg)), 
+      BBOX(local(st_bbox(in_aoi), crs = paste0("EPSG:", epsg))), 
       LIFE_CYCLE_STATUS_CODE == "ACTIVE") %>% 
     collect() %>% 
     dplyr::select(id, MAP_LABEL, FEATURE_LENGTH_M) %>% 


### PR DESCRIPTION
This is a fix due to a change in `bcdata` as of v0.4.0, From the [NEWS](https://github.com/bcgov/bcdata/blob/v0.4.0/NEWS.md):

* For WFS queries constructed using `bcdc_query_geodata()`, function calls in `filter()` that need to be evaluated locally are no-longer auto-detected. They now need to be wrapped in `local()` to force local evaluation before the `CQL` query is constructed and sent to the WFS server. Please see [`vignette("local-filter")`](https://bcgov.github.io/bcdata/articles/local-filter.html) for more information. This aligns with recommended usage patterns in other `dbplyr` backends (#304, PR #305).